### PR TITLE
Fix invalid cast for hash and use central package management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,9 +23,4 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
-
-  <!-- Shared Package Versions -->
-  <PropertyGroup>
-     <OrleansVersion>7.2.1</OrleansVersion>
-  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="7.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Streaming" Version="7.2.1" />
+  </ItemGroup>
+</Project>

--- a/Orleans.Streams.Utils.sln
+++ b/Orleans.Streams.Utils.sln
@@ -1,17 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31829.152
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Streams.Utils", "Orleans.Streams.Utils\Orleans.Streams.Utils.csproj", "{02F19193-AD76-497B-B12E-0139BB0BD5DB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{55DBDFE0-6B9A-4A29-B9CC-EF341E667569}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.github\workflows\build-publish.yml = .github\workflows\build-publish.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 		NuGet.Config = NuGet.Config
 		package.json = package.json
-		.github\workflows\build-publish.yml = .github\workflows\build-publish.yml
 	EndProjectSection
 EndProject
 Global

--- a/Orleans.Streams.Utils/Orleans.Streams.Utils.csproj
+++ b/Orleans.Streams.Utils/Orleans.Streams.Utils.csproj
@@ -5,7 +5,7 @@
     <PackageTags>orleans utilities streams providers streamprovider</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Streaming" Version="$(OrleansVersion)"/>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="$(OrleansVersion)"/>
+    <PackageReference Include="Microsoft.Orleans.Streaming" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
   </ItemGroup>
 </Project>

--- a/Orleans.Streams.Utils/QueueProperties.cs
+++ b/Orleans.Streams.Utils/QueueProperties.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streams.Utils
 			Namespace = @namespace;
 			PartitionId = partitionId;
 			QueueName = $"{@namespace}_{partitionId.ToString()}";
-			Hash = Convert.ToUInt32(XxHash64.Hash(Encoding.UTF8.GetBytes(@namespace)));
+			Hash = BitConverter.ToUInt32(XxHash64.Hash(Encoding.UTF8.GetBytes(@namespace)));
 			IsExternal = isExternal;
 			ExternalContractType = externalContractType;
 		}


### PR DESCRIPTION
Fixes `System.InvalidCastException : Unable to cast object of type 'System.Byte[]' to type 'System.IConvertible'.` in the `Hash` calculation of `QueueProperties. Occurs when running tests in [Orleans.Streams.Kafka](https://github.com/jonathansant/Orleans.Streams.Kafka) repo.

Also adopts Central Package Management https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management to clean up csproj files.